### PR TITLE
Fix/507

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,16 @@ that contains all the files.
 Here's a minimal example:
 
 ```python
+from os import environ
+
 from split_settings.tools import optional, include
+
+ENV = environ.get('ENV', 'local')
 
 include(
     'components/base.py',
     'components/database.py',
-    optional('local_settings.py')
+    optional('local_settings.py' if ENV == 'local' else None),
 )
 ```
 

--- a/split_settings/tools.py
+++ b/split_settings/tools.py
@@ -83,6 +83,10 @@ def include(*args: str, **kwargs) -> None:  # noqa: WPS210, WPS231, C901
     conf_path = os.path.dirname(including_file)
 
     for conf_file in args:
+        # skip optional empty values
+        if not conf_file and isinstance(conf_file, _Optional):
+            continue
+
         saved_included_file = scope.get(_INCLUDED_FILE)
         pattern = os.path.join(conf_path, conf_file)
 

--- a/tests/settings/merged/__init__.py
+++ b/tests/settings/merged/__init__.py
@@ -16,6 +16,9 @@ include(
     # Missing file:
     optional('components/missing_file.py'),
 
+    # Conditional inclusion:
+    optional('components/conditional.py' if False else None),  # noqa: WPS314
+
     # Scope:
     scope=globals(),  # noqa: WPS421
 )


### PR DESCRIPTION
sorry @sobolevn I've realized one thing.

Getting list of paths matching a non-existent pattern, returns empty list, which differs from getting a paths of parent folder (empty string).

```py
>>> import glob

>>> glob.glob('/tmp/None')  # Previous behavior
[]
>>> glob.glob('/tmp/')  # Current behavior
['/tmp/']
```

This adds a skip to Optional empty values (+unit-test & docs)