### PR TITLE
Migrate pyproject to use newer syntax for project urls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
   "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
 ]
 
-[tool.poetry.urls]
+[project.urls]
 "Funding" = "https://github.com/sponsors/wemake-services"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
# PR Summary
The `tool.poetry.urls` option is deprecated and should be replaced with `project.urls`:
```
Warning: [tool.poetry.urls] is deprecated. Use [project.urls] instead.
```
See [docs](https://packaging.python.org/en/latest/tutorials/packaging-projects/) for more information.